### PR TITLE
fix: lower vscode requirement to v1.99.0 for wider compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 		"url": "git://github.com/dandehoon/vscode-generic-expand-selection.git"
 	},
 	"engines": {
-		"vscode": "^1.101.0"
+		"vscode": "^1.99.0"
 	},
 	"categories": [
 		"Other"
@@ -100,7 +100,7 @@
 		"@eslint/js": "^9.29.0",
 		"@types/mocha": "^10.0.10",
 		"@types/node": "~22.15.33",
-		"@types/vscode": "^1.101.0",
+		"@types/vscode": "^1.99.0",
 		"@typescript-eslint/eslint-plugin": "^8.35.0",
 		"@typescript-eslint/parser": "^8.35.0",
 		"@vscode/test-cli": "^0.0.11",


### PR DESCRIPTION
Cursor is now forking vscode v1.99 so I can't install the extension to it. After checking the API competablity with Claude Code, no code need to change except lowering the vscode engin version for supporting Cursor. I already build and run it in my Cursor installation, everything works fine. 